### PR TITLE
Corrected height of month-name tab

### DIFF
--- a/kalenderRN.cls
+++ b/kalenderRN.cls
@@ -136,7 +136,7 @@
           % Print month name
           \draw (0,0)node [shape=rectangle,minimum height=.53cm,%
             text width=4.4cm,fill=dark,text=white,draw=dark,text centered]{%
-              \textbf{\pgfcalendarmonthname{\pgfcalendarcurrentmonth}}};}{}%
+              \resizebox{!}{.225cm}{\textbf{\pgfcalendarmonthname{\pgfcalendarcurrentmonth}}}};}{}%
         \ifdate{workday}{%
           \tikzset{every day/.style={fill=white}}%
           \RN@periods}{}%


### PR DESCRIPTION
The tab with the name of the month was too high for April, August and September. The letters 'p' and 'g' caused these tabs to be calculated higher than the others. I added a `resizebox` with a matching y-scale value. It's been at bit trial and error, but I found a size big enough for the text to be considered normal size and small enough to hinder the tab from making itself to big.
Unimportant side node: I discovered that by reducing the space between the month rows to 4.635cm (line 135). That way no whitespace is added between the months.
